### PR TITLE
Consumer cache retention

### DIFF
--- a/.github/workflows/version-and-release.yaml
+++ b/.github/workflows/version-and-release.yaml
@@ -25,7 +25,7 @@ jobs:
           go-version: '>=1.22.1'
 
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.64.0
+        uses: anothrNick/github-tag-action@1.67.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true

--- a/log_consumer/consumer_retention_test.go
+++ b/log_consumer/consumer_retention_test.go
@@ -1,0 +1,72 @@
+package log_consumer
+
+import (
+	"context"
+	"github.com/danthegoodman1/VirtualQueues/partitions"
+	"github.com/danthegoodman1/VirtualQueues/utils"
+	"testing"
+	"time"
+)
+
+func TestConsumerRetention(t *testing.T) {
+	t.Log("Test short retention")
+	topic := "testing"
+	offsetsTopic := "testing_offsets"
+	partitionTopic := "testing_p"
+	pm1 := partitions.Map{}
+	lc1, err := NewLogConsumer("lc1", "cg1", topic, offsetsTopic, partitionTopic, "localhost:11000", []string{"localhost:19092", "localhost:29092", "localhost:39092"}, 60000, &pm1, ConsumerRetention(time.Second, time.Millisecond*100, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second)
+	queue := "blah12" // gives partition 0 when 4 partitions
+	partition := utils.GetPartition(queue, 4)
+
+	// Write the consumer offset
+	t.Log("writing consumer offset")
+	consumer := "test_consumer_recovery"
+	err = lc1.WritePartitionConsumerOffset(context.Background(), partition, queue, consumer, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second * 2)
+
+	// Verify that it has expired
+	t.Log("checking consumer offsets")
+	consumerOffset := lc1.GetConsumerOffset(queue, consumer)
+	if consumerOffset != nil {
+		t.Fatal("got consumer offset even though it expired")
+	}
+
+	// Try restarting it
+	err = lc1.WritePartitionConsumerOffset(context.Background(), partition, queue, consumer, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Stop it
+	t.Log("shutting down to test recovery consumer expiry")
+	err = lc1.Shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second)
+
+	pm1 = partitions.Map{}
+	lc1, err = NewLogConsumer("lc1", "cg1", topic, offsetsTopic, partitionTopic, "localhost:11000", []string{"localhost:19092", "localhost:29092", "localhost:39092"}, 60000, &pm1, ConsumerRetention(time.Second, time.Millisecond*100, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second * 3)
+
+	// Verify that it has expired
+	t.Log("checking consumer offsets")
+	consumerOffset = lc1.GetConsumerOffset(queue, consumer)
+	if consumerOffset != nil {
+		t.Fatal("got consumer offset even though it expired")
+	}
+}

--- a/log_consumer/log_consumer_options.go
+++ b/log_consumer/log_consumer_options.go
@@ -1,0 +1,39 @@
+package log_consumer
+
+import (
+	"time"
+)
+
+type LogConsumerOption func(consumer *LogConsumer)
+
+// Creates an interval that will clear consumers that have not been updated in the retention window.
+// maxOps determines how many items to iterate over on the table max (control lock time).
+// 0 will always do the full map
+func ConsumerRetention(consumerRetention time.Duration, interval time.Duration, maxOps int64) LogConsumerOption {
+	return func(consumer *LogConsumer) {
+		go consumer.launchClearExpiredConsumersInterval(consumerRetention, maxOps, time.NewTicker(interval))
+	}
+}
+
+func (lc *LogConsumer) launchClearExpiredConsumersInterval(consumerRetention time.Duration, maxOps int64, ticker *time.Ticker) {
+	for {
+		<-ticker.C
+		go func() {
+			lc.consumerOffsetsMu.Lock()
+			defer lc.consumerOffsetsMu.Unlock()
+			ops := int64(0)
+			for key, offset := range lc.consumerOffsets {
+				if time.Now().Sub(offset.Created) > consumerRetention {
+					delete(lc.consumerOffsets, key)
+					lc.partitionConsumers.Delete(key)
+				}
+
+				ops++
+				if maxOps > 0 && ops >= maxOps {
+					// We have hit the max, return
+					return
+				}
+			}
+		}()
+	}
+}

--- a/log_consumer/log_consumer_options.go
+++ b/log_consumer/log_consumer_options.go
@@ -6,7 +6,7 @@ import (
 
 type LogConsumerOption func(consumer *LogConsumer)
 
-// Creates an interval that will clear consumers that have not been updated in the retention window.
+// ConsumerRetention creates an interval that will clear consumers that have not been updated in the retention window.
 // maxOps determines how many items to iterate over on the table max (control lock time).
 // 0 will always do the full map
 func ConsumerRetention(consumerRetention time.Duration, interval time.Duration, maxOps int64) LogConsumerOption {

--- a/log_consumer/log_consumer_options.go
+++ b/log_consumer/log_consumer_options.go
@@ -11,6 +11,7 @@ type LogConsumerOption func(consumer *LogConsumer)
 // 0 will always do the full map
 func ConsumerRetention(consumerRetention time.Duration, interval time.Duration, maxOps int64) LogConsumerOption {
 	return func(consumer *LogConsumer) {
+		consumer.consumerRetention = &consumerRetention
 		go consumer.launchClearExpiredConsumersInterval(consumerRetention, maxOps, time.NewTicker(interval))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -31,6 +31,12 @@ func main() {
 
 	pm := partitions.Map{}
 
+	var opts []log_consumer.LogConsumerOption
+
+	if utils.Env_ConsumerRetention != 0 && utils.Env_ConsumerRetentionInterval != 0 {
+		opts = append(opts, log_consumer.ConsumerRetention(time.Duration(utils.Env_ConsumerRetention)*time.Second, time.Duration(utils.Env_ConsumerRetentionInterval)*time.Second, utils.Env_ConsumerRetentionMaxOps))
+	}
+
 	var logConsumer *log_consumer.LogConsumer
 	g.Go(func() (err error) {
 		logConsumer, err = log_consumer.NewLogConsumer(utils.Env_InstanceID, utils.Env_ConsumerGroup, utils.Env_KafkaDataTopic, utils.Env_KafkaOffsetTopic, utils.Env_KafkaDataTopic, utils.Env_AdvertiseAddr, strings.Split(utils.Env_KafkaSeeds, ","), utils.Env_KafkaSessionMs, &pm)

--- a/utils/env.go
+++ b/utils/env.go
@@ -30,4 +30,8 @@ var (
 	Env_GossipDebug = os.Getenv("GOSSIP_DEBUG") == "1"
 
 	Env_Profile = os.Getenv("PROFILE") == "1"
+
+	Env_ConsumerRetention         = MustEnvOrDefaultInt64("CONSUMER_RETENTION", 0)
+	Env_ConsumerRetentionInterval = MustEnvOrDefaultInt64("CONSUMER_RETENTION_INTERVAL", 0)
+	Env_ConsumerRetentionMaxOps   = MustEnvOrDefaultInt64("CONSUMER_RETENTION_MAX_OPS", 0)
 )


### PR DESCRIPTION
Adds configuration options to log consumer

Adds option to set consumer retention

Adds tests

Adds option from env vars to configure on process start

Closes #8

#minor